### PR TITLE
Add visible text selection helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ print(f"Downloaded file: {downloaded_file}")
 
 ### 3. Interacting with Web Elements
 
-Use the custom methods `send_keys`, `click`, `select_by_value`, and `submit_form` to interact with web elements:
+Use the custom methods `send_keys`, `click`, `select_by_value`, `select_by_visible_text`, and `submit_form` to interact with web elements:
 
 ```python
 driver.send_keys("//input[@id='search']", "search term")

--- a/src/customchromedriver/customchromedriver.py
+++ b/src/customchromedriver/customchromedriver.py
@@ -330,6 +330,13 @@ class CustomChromeDriver(webdriver.Chrome):
         )
         Select(select_element).select_by_value(value)
 
+    def select_by_visible_text(self, xpath, text):
+        # ドロップダウンメニューが表示されるまで待機
+        select_element = WebDriverWait(self, 10).until(
+            EC.presence_of_element_located((By.XPATH, xpath))
+        )
+        Select(select_element).select_by_visible_text(text)
+
     def submit_form(self, xpath):
         # フォームが表示されるまで待機
         form = WebDriverWait(self, 10).until(


### PR DESCRIPTION
## Summary
- add `select_by_visible_text` method to select options by text
- document new helper in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503b69689c8332a40ecb120dba1a90