### PR TITLE
Add helper to accept alerts

### DIFF
--- a/src/customchromedriver/customchromedriver.py
+++ b/src/customchromedriver/customchromedriver.py
@@ -39,26 +39,36 @@ INSTRUCTION_HTML = """\
 </html>
 """
 
-def ensure_profile(profile: str, chrome_path: str = r"C:\Program Files\Google\Chrome\Application\chrome.exe"):
+
+def ensure_profile(
+    profile: str,
+    chrome_path: str = r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+):
     profile_path = Path(f"C:/selenium_profiles/{profile}")
-    
+
     if not profile_path.exists():
         print(f"[INFO] プロファイル '{profile}' が存在しません。初期化を行います。")
 
         # 一時HTMLファイル作成
-        with tempfile.NamedTemporaryFile("w", suffix=".html", delete=False, encoding="utf-8") as f:
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".html", delete=False, encoding="utf-8"
+        ) as f:
             f.write(INSTRUCTION_HTML)
             instruction_path = f.name
 
         # Chromeで起動＋手順ページ表示
-        subprocess.Popen([
-            chrome_path,
-            f"--user-data-dir={profile_path}",
-            "--new-window",
-            "file:///" + instruction_path.replace("\\", "/")
-        ])
+        subprocess.Popen(
+            [
+                chrome_path,
+                f"--user-data-dir={profile_path}",
+                "--new-window",
+                "file:///" + instruction_path.replace("\\", "/"),
+            ]
+        )
 
-        print(f"[ACTION] Chromeが起動しました。初期設定を行い、完了したらウィンドウを閉じてください。")
+        print(
+            f"[ACTION] Chromeが起動しました。初期設定を行い、完了したらウィンドウを閉じてください。"
+        )
         input("[ENTER] 続行するにはEnterキーを押してください。")
 
         # （任意）初期化後にファイル削除したければコメントを外す
@@ -68,13 +78,16 @@ def ensure_profile(profile: str, chrome_path: str = r"C:\Program Files\Google\Ch
 
 
 def get_chromedriver_dir():
-    return Path(__file__).parent / 'ChromeDriver'
+    return Path(__file__).parent / "ChromeDriver"
+
 
 class ChromeVersionManager:
     @staticmethod
     def get_chrome_version():
         try:
-            key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\Google\Chrome\BLBeacon")
+            key = winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER, r"Software\Google\Chrome\BLBeacon"
+            )
             version, _ = winreg.QueryValueEx(key, "version")
             return version
         except FileNotFoundError:
@@ -82,13 +95,13 @@ class ChromeVersionManager:
 
     @staticmethod
     def get_major_version(v):
-        return int(v.base_version.split('.')[0])
+        return int(v.base_version.split(".")[0])
 
     @staticmethod
     def version_diff_tuple(v1, v2):
-        v1_parts = list(map(int, v1.base_version.split('.')))
-        v2_parts = list(map(int, v2.base_version.split('.')))
-        
+        v1_parts = list(map(int, v1.base_version.split(".")))
+        v2_parts = list(map(int, v2.base_version.split(".")))
+
         # 各パーツの差分の絶対値をタプルで返す
         return tuple(abs(p1 - p2) for p1, p2 in zip(v1_parts, v2_parts))
 
@@ -97,31 +110,34 @@ class ChromeVersionManager:
         target_major_version = ChromeVersionManager.get_major_version(target_version)
         closest_version = None
         smallest_diff_tuple = None
-    
+
         # メジャーバージョン一覧を作成
         major_versions = set()
-        
-        for v in df['Version']:
+
+        for v in df["Version"]:
             parsed_v = version.parse(v)
             major_version = ChromeVersionManager.get_major_version(parsed_v)
             major_versions.add(major_version)
-            
+
             # メジャーバージョンが一致する場合にのみ比較
             if major_version == target_major_version:
-                diff_tuple = ChromeVersionManager.version_diff_tuple(parsed_v, target_version)
-                
+                diff_tuple = ChromeVersionManager.version_diff_tuple(
+                    parsed_v, target_version
+                )
+
                 if smallest_diff_tuple is None or diff_tuple < smallest_diff_tuple:
                     smallest_diff_tuple = diff_tuple
                     closest_version = v
-    
+
         # 一致するメジャーバージョンが見つからなかった場合にエラーを発生させる
         if closest_version is None:
-            major_versions_list = ', '.join(map(str, sorted(major_versions)))
-            raise ValueError(f"No matching major version found for target version {target_version}. "
-                             f"Please update your Chrome version to one of the following major versions: {major_versions_list}.")
-    
-        return closest_version
+            major_versions_list = ", ".join(map(str, sorted(major_versions)))
+            raise ValueError(
+                f"No matching major version found for target version {target_version}. "
+                f"Please update your Chrome version to one of the following major versions: {major_versions_list}."
+            )
 
+        return closest_version
 
     @staticmethod
     def get_chromedriver_url():
@@ -133,21 +149,26 @@ class ChromeVersionManager:
         current_version = version.parse(ChromeVersionManager.get_chrome_version())
 
         # 一番近いバージョンを取得
-        closest_version = ChromeVersionManager.find_closest_version(versions, current_version)
+        closest_version = ChromeVersionManager.find_closest_version(
+            versions, current_version
+        )
 
         # 一致するバージョンのチャネルを取得
-        channel = versions.query('Version == @closest_version')['Channel'].item()
+        channel = versions.query("Version == @closest_version")["Channel"].item()
         url_lists = channel2url_lists[channel]
 
         # ChromedriverのダウンロードURLを取得
         url_info = url_lists.query('Binary == "chromedriver" and Platform == "win64"')
 
         # HTTPステータスチェック
-        if url_info['HTTP status'].item() != 200:
-            raise Exception(f"Failed to get a valid download link. HTTP Status: {url_info['HTTP status'].item()}")
-        
-        chromedriver_url = url_info['URL'].item()
+        if url_info["HTTP status"].item() != 200:
+            raise Exception(
+                f"Failed to get a valid download link. HTTP Status: {url_info['HTTP status'].item()}"
+            )
+
+        chromedriver_url = url_info["URL"].item()
         return chromedriver_url
+
 
 # 既定のパスにChromeDriverをダウンロードして解凍する関数
 def update_chromedriver():
@@ -157,14 +178,14 @@ def update_chromedriver():
     # Tempfileに一時的にファイルをダウンロード
     with tempfile.TemporaryDirectory() as tmpdirname:
         temp_zip_path = os.path.join(tmpdirname, "chromedriver.zip")
-        
+
         # ダウンロードを実行
         print(f"Downloading ChromeDriver from {chromedriver_url} to temporary file...")
         response = requests.get(chromedriver_url, stream=True)
-        
+
         # ステータスコードを確認しraise_for_statusを使用
         response.raise_for_status()
-        
+
         # 一時ファイルに書き込み
         with open(temp_zip_path, "wb") as f:
             for chunk in response.iter_content(chunk_size=8192):
@@ -183,7 +204,7 @@ def update_chromedriver():
         shutil.unpack_archive(temp_zip_path, driver_dir)
 
     print(f"ChromeDriver unpacked successfully to {driver_dir}")
-    
+
 
 class CustomChromeDriver(webdriver.Chrome):
     def __init__(self, headless=False, download_folder=None, profile=None):
@@ -201,36 +222,41 @@ class CustomChromeDriver(webdriver.Chrome):
         options = webdriver.ChromeOptions()
         options.use_chromium = True
         if headless:
-            options.add_argument('--headless')
+            options.add_argument("--headless")
             # Chrome129のchromedriverをheadlessモードで起動した際、白いウィンドウが出るバグがある
             # 回避策として、headlessモードのとき、ウィンドウ位置を端にする
             options.add_argument("--window-position=-2400,-2400")
         try:
-            chromedriver_path = next(get_chromedriver_dir().glob('**/chromedriver.exe'))
+            chromedriver_path = next(get_chromedriver_dir().glob("**/chromedriver.exe"))
         except StopIteration:
             # chromedriverが既定の場所に見当たらないとき
             # chromedriverをダウンロードする
             update_chromedriver()
-            chromedriver_path = next(get_chromedriver_dir().glob('**/chromedriver.exe'))
+            chromedriver_path = next(get_chromedriver_dir().glob("**/chromedriver.exe"))
 
         if profile is not None:
             user_data_dir = ensure_profile(profile)
             options.add_argument(f"user-data-dir={user_data_dir}")
-        
+
         # WebDriverWaitを使うことを考慮し、全要素の読み込みを待たずにdriver.get関数を返すように変更
-        options.page_load_strategy = 'eager'
+        options.page_load_strategy = "eager"
 
         # 不要なログを非表示に
-        options.add_argument('log-level=1')
-        options.add_experimental_option("excludeSwitches", ['enable-logging'])
+        options.add_argument("log-level=1")
+        options.add_experimental_option("excludeSwitches", ["enable-logging"])
 
-        self.download_folder = Path(download_folder).absolute() if download_folder else Path.cwd()
-        options.add_experimental_option('prefs', {
-            "download.default_directory": str(self.download_folder),
-            "download.prompt_for_download": False,  # ダウンロード時の確認ダイアログを無効化
-            "download.directory_upgrade": True,
-            "plugins.always_open_pdf_externally": True
-        })
+        self.download_folder = (
+            Path(download_folder).absolute() if download_folder else Path.cwd()
+        )
+        options.add_experimental_option(
+            "prefs",
+            {
+                "download.default_directory": str(self.download_folder),
+                "download.prompt_for_download": False,  # ダウンロード時の確認ダイアログを無効化
+                "download.directory_upgrade": True,
+                "plugins.always_open_pdf_externally": True,
+            },
+        )
 
         # DevToolsイベントを有効にするためにcapabilitiesを設定（コメントアウトされた部分）
         # options.set_capability("goog:loggingPrefs", {"performance": "ALL"})
@@ -244,18 +270,18 @@ class CustomChromeDriver(webdriver.Chrome):
                 super().__init__(options=options)
         except SessionNotCreatedException as e:
             # driverのバージョンが合わない場合
-            print('install latest chromedriver')
+            print("install latest chromedriver")
 
             update_chromedriver()
 
             # 再実行
             service = Service(executable_path=str(chromedriver_path))
             super().__init__(service=service, options=options)
-            
+
     def download_and_track_file(self, download_link, timeout=30, extensions=None):
         """
         Downloads a file from the given link and returns the path to the downloaded file.
-    
+
         Parameters
         ----------
         download_link : str
@@ -264,42 +290,44 @@ class CustomChromeDriver(webdriver.Chrome):
             The maximum time to wait for the download to complete, in seconds. Default is 30 seconds.
         extensions : list, str, or None, optional
             List of file extensions or a single extension to filter the downloaded files. If None, all files are considered.
-    
+
         Returns
         -------
         Path
             The path to the downloaded file.
-    
+
         Raises
         ------
         TimeoutException
             If the download does not complete within the specified timeout.
         """
         if extensions is None:
-            pattern = '*'
+            pattern = "*"
         elif isinstance(extensions, str):
             pattern = f"*.{extensions}"
         else:
             pattern = f"*{{{','.join(extensions)}}}"
-        
+
         download_folder_existing_files = set(self.download_folder.glob(pattern))
-    
+
         # ダウンロードリンクに移動
         self.get(download_link)
-    
+
         # 新しいファイルがダウンロードされるのを待機
         downloaded_file_path = None
         start_time = time.time()
         while time.time() - start_time < timeout:
-            new_files = set(self.download_folder.glob(pattern)) - download_folder_existing_files
+            new_files = (
+                set(self.download_folder.glob(pattern)) - download_folder_existing_files
+            )
             if new_files:
                 downloaded_file_path = list(new_files)[0]
                 break
             time.sleep(1)
-    
+
         if downloaded_file_path is None:
             raise TimeoutException("ファイルのダウンロードが完了しませんでした。")
-    
+
         return downloaded_file_path
 
     def send_keys(self, xpath, value):
@@ -332,6 +360,10 @@ class CustomChromeDriver(webdriver.Chrome):
         )
         # フォームを送信
         form.submit()
+
+    def accept_alert(self, timeout=10):
+        alert = WebDriverWait(self, timeout).until(EC.alert_is_present())
+        alert.accept()
 
     def read_html(self, xpath=None, **kwargs):
         if xpath is None:


### PR DESCRIPTION
## Summary
- add `accept_alert` helper to wait for browser alerts and accept them

## Testing
- `python -m pytest -q`
- `python -m flake8` *(fails: No module named flake8)*


------
https://chatgpt.com/codex/tasks/task_e_68932ff658c08332ac5d30397d4bad81